### PR TITLE
Don't add "; modified by iTextSharp <version>" to the producer field if it has been overridden

### DIFF
--- a/src/core/iTextSharp/text/pdf/PdfStamperImp.cs
+++ b/src/core/iTextSharp/text/pdf/PdfStamperImp.cs
@@ -208,12 +208,6 @@ namespace iTextSharp4.text.pdf {
             if (producer == null) {
                 producer = Document.Version;
             }
-            else if (producer.IndexOf(Document.Product) == -1) {
-                StringBuilder buf = new StringBuilder(producer);
-                buf.Append("; modified using ");
-                buf.Append(Document.Version);
-                producer = buf.ToString();
-            }
             // XMP
             byte[] altMetadata = null;
             PdfObject xmpo = PdfReader.GetPdfObject(catalog.Get(PdfName.METADATA));


### PR DESCRIPTION
iTextSharp adds its name and version to the producer, even if the field has been overridden using:

    writer.Info.Put(PdfName.PRODUCER, new PdfString("MyProducer"));

With this change it still adds iTextSharp as producer if the producer field hasn't been set at all, but doesn't modify it if it has been overridden.